### PR TITLE
Fix Firestore permissions and missing ArrowRight import

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,13 +7,25 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId;
       
       // Allow users to read and write their own subcollections
-      match /{document=**} {
+      match /{document=} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
     }
     
+    // Allow authenticated users to read and query resources collection
+    match /resources {
+      allow read: if request.auth != null;
+    }
+    
+    // Allow authenticated users to read resources
+    match /resources/{resourceId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+      allow update, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+    }
+    
     // Deny all other access
-    match /{document=**} {
+    match /{document=} {
       allow read, write: if false;
     }
   }

--- a/src/components/dashboard/ProgressOverview.tsx
+++ b/src/components/dashboard/ProgressOverview.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { useTheme } from '../../context/ThemeContext';
-import { Trophy, Target, Flame, Clock, CheckCircle, BookOpen, TrendingUp, Sparkles, Star, Zap, Plus, X, Save, Calendar, Play, RefreshCw } from 'lucide-react';
+import { Trophy, Target, Flame, Clock, CheckCircle, BookOpen, TrendingUp, Sparkles, Star, Zap, Plus, X, Save, Calendar, Play, RefreshCw, ArrowRight } from 'lucide-react';
 import WhatsNext from './WhatsNext';
 
 const ProgressOverview: React.FC = () => {


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update Firestore rules to fix permissions for resource access and add missing `ArrowRight` import in `ProgressOverview.tsx`.

### Why are these changes being made?

The Firestore rule change corrects a previous error in document path matching and grants specific access to authenticated users for the `resources` collection, addressing read and write permissions issues. The missing `ArrowRight` import in `ProgressOverview.tsx` is added to prevent potential errors related to icon usage in the component.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->